### PR TITLE
Removable container controls

### DIFF
--- a/src/container/group.control.spec.ts
+++ b/src/container/group.control.spec.ts
@@ -91,7 +91,9 @@ describe('InGroup', () => {
 
     describe('set', () => {
       it('adds control', () => {
-        group.controls.set('ctrl3', ctrl3);
+
+        const supply = group.controls.set('ctrl3', ctrl3);
+
         expect([...lastSnapshot]).toEqual([ctrl1, ctrl2, ctrl3]);
         expect([...lastSnapshot.entries()]).toEqual([['ctrl1', ctrl1], ['ctrl2', ctrl2], ['ctrl3', ctrl3]]);
         expect(lastSnapshot.get('ctrl1')).toBe(ctrl1);
@@ -100,12 +102,14 @@ describe('InGroup', () => {
         expect(onUpdate).toHaveBeenCalledWith([['ctrl3', ctrl3]], []);
         expect(readSnapshot).toHaveBeenCalledTimes(1);
         expect(parentsOf(ctrl3)).toEqual([{ parent: group }]);
+
+        supply.off();
+        expect([...lastSnapshot]).toEqual([ctrl1, ctrl2]);
       });
       it('replaces control', () => {
 
         const ctrl4 = inValue('third');
-
-        group.controls.set('ctrl1', ctrl4);
+        const supply = group.controls.set('ctrl1', ctrl4);
 
         expect([...lastSnapshot]).toEqual([ctrl4, ctrl2]);
         expect([...lastSnapshot.entries()]).toEqual([['ctrl1', ctrl4], ['ctrl2', ctrl2]]);
@@ -116,6 +120,13 @@ describe('InGroup', () => {
         expect(readSnapshot).toHaveBeenCalledTimes(1);
         expect(parentsOf(ctrl1)).toHaveLength(0);
         expect(parentsOf(ctrl4)).toEqual([{ parent: group }]);
+
+        group.controls.set('ctrl1', ctrl1);
+
+        const whenOff = jest.fn();
+
+        supply.whenOff(whenOff);
+        expect(whenOff).toHaveBeenCalledWith(undefined);
       });
       it('does not replace control with itself', () => {
         group.controls.set('ctrl1', ctrl1);
@@ -142,11 +153,11 @@ describe('InGroup', () => {
       it('sets multiple controls', () => {
 
         const ctrl4 = inValue('third');
-
-        group.controls.set({
+        const supply = group.controls.set({
           ctrl1: ctrl4,
           ctrl3,
         });
+
         expect([...lastSnapshot]).toEqual([ctrl4, ctrl2, ctrl3]);
         expect([...lastSnapshot.entries()]).toEqual([['ctrl1', ctrl4], ['ctrl2', ctrl2], ['ctrl3', ctrl3]]);
         expect(lastSnapshot.get('ctrl1')).toBe(ctrl4);
@@ -154,6 +165,9 @@ describe('InGroup', () => {
         expect(lastSnapshot.get('ctrl3')).toBe(ctrl3);
         expect(onUpdate).toHaveBeenCalledWith([['ctrl1', ctrl4], ['ctrl3', ctrl3]], [['ctrl1', ctrl1]]);
         expect(readSnapshot).toHaveBeenCalledTimes(1);
+
+        supply.off();
+        expect([...lastSnapshot]).toEqual([ctrl2]);
       });
     });
 

--- a/src/container/group.control.spec.ts
+++ b/src/container/group.control.spec.ts
@@ -197,7 +197,7 @@ describe('InGroup', () => {
 
     describe('clear', () => {
       it('removes all controls', () => {
-        expect(group.controls.clear()).toBe(group.controls);
+        group.controls.clear();
         expect([...lastSnapshot]).toHaveLength(0);
         expect(onUpdate).toHaveBeenCalledWith([], [['ctrl1', ctrl1], ['ctrl2', ctrl2]]);
         expect(onUpdate).toHaveBeenCalledTimes(1);

--- a/src/container/group.control.ts
+++ b/src/container/group.control.ts
@@ -163,10 +163,8 @@ export abstract class InGroupControls<Model>
 
   /**
    * Removes all input controls.
-   *
-   * @returns `this` controls instance.
    */
-  abstract clear(): this;
+  abstract clear(): void;
 
 }
 
@@ -420,15 +418,13 @@ class InGroupControlControls<Model extends object> extends InGroupControls<Model
     }
   }
 
-  clear(): this {
+  clear(): void {
 
     const removed = this._map.clear();
 
     if (removed.length) {
       this._updates.send([], removed);
     }
-
-    return this;
   }
 
 }

--- a/src/container/list.control.spec.ts
+++ b/src/container/list.control.spec.ts
@@ -130,8 +130,11 @@ describe('InList', () => {
     });
 
     describe('set', () => {
+
+      let supply: EventSupply;
+
       beforeEach(() => {
-        list.controls.set(1, ctrl2);
+        supply = list.controls.set(1, ctrl2);
       });
 
       it('replaces control', () => {
@@ -147,6 +150,19 @@ describe('InList', () => {
       });
       it('registers control parent', () => {
         ctrl2.aspect(InParents).read.once(parents => expect([...parents]).toEqual([{ parent: list }]));
+      });
+      it('removes control once returned supply cut off', () => {
+        supply.off();
+        expect([...snapshot]).toEqual([initControls[0], initControls[2]]);
+      });
+      it('cuts off the supply of replaced control', () => {
+        list.controls.set(1, ctrl3);
+        expect([...snapshot]).toEqual([initControls[0], ctrl3, initControls[2]]);
+
+        const whenOff = jest.fn();
+
+        supply.whenOff(whenOff);
+        expect(whenOff).toHaveBeenCalledWith(undefined);
       });
     });
 
@@ -208,8 +224,11 @@ describe('InList', () => {
     });
 
     describe('insert', () => {
+
+      let supply: EventSupply;
+
       beforeEach(() => {
-        list.controls.insert(1, ctrl1, ctrl2);
+        supply = list.controls.insert(1, ctrl1, ctrl2);
       });
 
       it('inserts controls', () => {
@@ -223,6 +242,10 @@ describe('InList', () => {
       });
       it('updates model', () => {
         expect(list.it).toEqual(['11', '1', '2', '22', '33']);
+      });
+      it('removes inserted control once returned supply cut off', () => {
+        supply.off();
+        expect([...snapshot]).toEqual([initControls[0], initControls[1], initControls[2]]);
       });
     });
 


### PR DESCRIPTION
Container modifiers return control supplies that removes added controls once cut off